### PR TITLE
fix(docs): fix broken Markdown syntax

### DIFF
--- a/docs/top.md
+++ b/docs/top.md
@@ -23,7 +23,7 @@ What follows is an overview of the project, but if you're eager to get in to the
 
 ## Motivation
 
-There are many many diagramming solutions, so why HDElk? WYSIWYG editors are high touch, by design. This means it is sometimes hard to control the look and feel of a diagram, and it can also be quite hard to maintain (for example, change the name of something, change the size of all nodes, etc.).  There are a (number of Javascript diagrammers)[https://modeling-languages.com/javascript-drawing-libraries-diagrams/] but very often they are complex and often don't depict nodes and ports efficiently.  The great project [WaveDrom](https://wavedrom.com/) shows the way.  Its job is to draw waveforms, but rather than provide an online WYSIWYG tool or omnibus draw anything library, it lets the user describe the diagram in a very domain specific JSON right in the page.  Wavedrom then renders the wave in SVG.
+There are many many diagramming solutions, so why HDElk? WYSIWYG editors are high touch, by design. This means it is sometimes hard to control the look and feel of a diagram, and it can also be quite hard to maintain (for example, change the name of something, change the size of all nodes, etc.).  There are a [number of JavaScript diagrammers](https://modeling-languages.com/javascript-drawing-libraries-diagrams/) but very often they are complex and often don't depict nodes and ports efficiently.  The great project [WaveDrom](https://wavedrom.com/) shows the way.  Its job is to draw waveforms, but rather than provide an online WYSIWYG tool or omnibus draw anything library, it lets the user describe the diagram in a very domain specific JSON right in the page.  Wavedrom then renders the wave in SVG.
 
 ![]({{site.baseurl}}/assets/images/wavedrom.png)
 
@@ -33,7 +33,7 @@ Back to rendering HDL, it should be noted that a much more sophisticated tool th
 
 ![]({{site.baseurl}}/assets/images/netlistsvg.svg)
 
-This is an SVG sample from the home page.  Clearly if you want real diagrams generated from actual code, NetListSVG is the project to look into.  NetListSVG uses [Elk.JS](https://github.com/OpenKieler/elkjs) for its layout, and was an inspiration for HDElk.
+This is an SVG sample from the home page.  Clearly if you want real diagrams generated from actual code, NetListSVG is the project to look into.  NetListSVG uses [ElkJS](https://github.com/OpenKieler/elkjs) for its layout, and was an inspiration for HDElk.
 
 ## Simple Example
 
@@ -112,7 +112,7 @@ For completeness, somewhere the following library files need to be loaded.  They
 
 ## How it Works
 
-The system is based around [ElkJS](https://github.com/OpenKieler/elkjs), a Javascript translation of [Elk](https://www.eclipse.org/elk/), the Eclipse Layout Kernel.  This codebase, which is under 1000 lines, takes textual specifications of a graph of nodes and edges and arranges them into something that can be displayed on a 2D screen.  That is where ElkJs ends, with a JavaScript object with added locations and sizes.  From there something has to render the objects, adding styles, etc.  This is what HDElk does, with the help of [SVG.js](https://svgjs.com/), a small library that makes generating SVG trivial.
+The system is based around [ElkJS](https://github.com/OpenKieler/elkjs), a JavaScript translation of [Elk](https://www.eclipse.org/elk/), the Eclipse Layout Kernel.  This codebase, which is under 1000 lines, takes textual specifications of a graph of nodes and edges and arranges them into something that can be displayed on a 2D screen.  That is where ElkJs ends, with a JavaScript object with added locations and sizes.  From there something has to render the objects, adding styles, etc.  This is what HDElk does, with the help of [SVG.js](https://svgjs.com/), a small library that makes generating SVG trivial.
 
 ElkJS uses a rather long form of description.
 
@@ -234,16 +234,16 @@ The two main functions that do HDElk work are `transform()` and `diagram()` both
 
 ## Future Work
 
-Enhancements
+### Enhancements
 
 - **Add a live editor** Create a live editor for experimentation
 - **Add a gallery** Create page with a few examples
 - **Push Error Messages Into the Div** When there is a problem, make sure error messages are visible
 - **Create a Style system** There is only one "style", any others are the "find the place in the code and change it" kind
-- **Add instructions for use with NodeJS** So far this is a browser focused effort.
+- **Add instructions for use with Node.js** So far this is a browser focused effort.
 - **Add more highlight colors** Orange and Purple!
 
-Bugs
+### Bugs
 
 - **Elk Node Label Bug** There seems to be a bug when labels are not centered.  The space allowed is made twice as big as it should be.  Leaf nodes in HDElk have centered labels so this is OK, but parent nodes do reserve too label space since the labels are H_CENTER, V_TOP
 - **Elk Self Connection Label Bug** Labels on edges connecting two ports on the same node do not appear.


### PR DESCRIPTION
- Fix broken Markdown syntax
- Improve text consistency
  - Rename "Javascript" to "JavaScript"
  - Rename "Elk.JS" to "ElkJS"
  - Rename "NodeJS" to "Node.js"
- Add level 3 text headings to improve readability